### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,16 @@
+{
+  "name": "EBV lytic expression",
+  "install": "pip3 install --break-system-packages -r ebv_lytic_expression/requirements.txt",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "python3 -m http.server 8000 --bind 0.0.0.0 --directory ebv_lytic_expression/web"
+    }
+  ],
+  "ports": [
+    {
+      "name": "web",
+      "port": 8000
+    }
+  ]
+}

--- a/ebv_lytic_expression/requirements.txt
+++ b/ebv_lytic_expression/requirements.txt
@@ -1,0 +1,4 @@
+# Python dependencies for the Yuan 2006 EBV lytic RNA timecourse figure generator.
+matplotlib>=3.11,<4
+numpy>=2.4,<3
+pandas>=3.0,<4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for this repository, which previously had no dependency or environment configuration. The project has two runnable components:

- A Python figure generator (`ebv_lytic_expression/plot_yuan2006_timecourse.py`) that reads the curated Yuan 2006 CSV and renders a matplotlib PNG of EBV lytic RNA kinetics.
- A static web app (`ebv_lytic_expression/web/`) — an interactive SVG chart of the same timecourse.

## Changes

- Add `ebv_lytic_expression/requirements.txt` pinning `matplotlib`, `numpy`, and `pandas`.
- Add `.cursor/environment.json` (repo-managed, highest-precedence config that follows branches/PRs):
  - `install` refreshes Python dependencies (idempotent).
  - a `web` terminal serves the static app on `0.0.0.0:8000`.
  - exposes port `8000`.

## Validation

| Check | Result |
| --- | --- |
| `install` idempotence | Passed twice |
| Python figure generator (59-gene PNG) | Passed |
| Web app served (HTTP 200 all assets) | Passed |
| Interactive chart (pin/hover/toggle/search) | Passed in-browser |
| Prebuilt environment build | SUCCEEDED |
| Fresh Cloud Agent booted from build | 5/5 checks passed |

### Web app demo

[ebv_web_app_demo.mp4](https://cursor.com/agents/bc-28df8c14-4ef2-461e-bbff-061182cd6955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Febv_web_app_demo.mp4)

### Python figure output

[Yuan 2006 EBV lytic RNA timecourse figure](https://cursor.com/agents/bc-28df8c14-4ef2-461e-bbff-061182cd6955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpython_figure_yuan2006_timecourse.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28df8c14-4ef2-461e-bbff-061182cd6955?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28df8c14-4ef2-461e-bbff-061182cd6955&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

